### PR TITLE
Fixed edu-git-fetch: REF message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,12 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [ ] Portuguese translation.
 - [ ] German Translation
 - [ ] Italian translation
 - [ ] French translation
 - [ ] Script `edu-git-checkout`
 - [ ] yaml people spectification
+
+### Fixed
+
+- [x] `edu-git-fetch` did not indicate the non-existent ref error
+
+## [0.11.0-alpha.0] - 2024-10-16
+
+### Added
+
+- Portuguese translation.
 
 ## [0.10.0-alpha.0] - 2024-10-13
 

--- a/handlers/edu-git-fetch-handler.js
+++ b/handlers/edu-git-fetch-handler.js
@@ -21,7 +21,8 @@ async function fetch(argv) {
             await repo.fetch(alias, branch_for_fetch)
             .then( (sumary, a, b, c) => { 
                 sumarize(null, repo.cmd, sumary)} 
-            ).catch((error) => { 
+            ).catch((error) => {
+                error.branch = branch_for_fetch;
                 sumarize(error, repo.cmd)}
             );
             
@@ -47,7 +48,12 @@ async function sumarize(error, cmd, sumary){
             cambios = `(${i18n.__n('fetch.cambios', sumary.updated.length)})`;
             commit = `(${sumary.updated[0].to})`;
         }
-    } else stage = gitStates.stateFAIL;
+    } else {
+        // Evalúo tipo de error
+        stage = error.message.includes(error.branch) ?
+            gitStates.stateREF : 
+            gitStates.stateFAIL;
+    }
 
     getLogger().info(`${stage}\`${cmd}\` ${commit} ${cambios}`);
 }


### PR DESCRIPTION
Fix #4. Corrige el bug de indicación de error porque no existe la referencia o rama de la que se está haciendo un fetch con `edu-git-fetch`