### PR TITLE
Fixed #6. Corrección de path para los bare repos de archivo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI outputs improvements (refactoring colorize, sumarize...)
 - gitStates colors
 
+### Fixed
+
+- [x] Path del repo de archivo bare (iss #6)
+
 ## [0.9.2-alpha] - 2024-10-13
 
 This was the first version released on npm, resulting from some bash scripts that were migrated to node and python.

--- a/handlers/edu-git-archive-handler.js
+++ b/handlers/edu-git-archive-handler.js
@@ -6,7 +6,7 @@ const { getLogger } = require('../helpers/logger');
 const i18n = require('../helpers/translator');
 const { exit } = require('process');
 
-const bare_repos_path = "../archive2";
+const bare_repos_path = "../archive";
 const bare_repo_name = "archive";
 
 async function archive(argv) {


### PR DESCRIPTION
Con efectos de depuración se utilizó un patch para los bare repos distinto `../archive2`. Se corrige para que sea `../archive`

Fixed #6 